### PR TITLE
Set up cors filter that allows cross origin requests

### DIFF
--- a/src/main/java/com/codewithdean/blog/blogapp/config/SecurityConfig.java
+++ b/src/main/java/com/codewithdean/blog/blogapp/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.codewithdean.blog.blogapp.security.CustomUserDetailService;
 import com.codewithdean.blog.blogapp.security.JwtAuthenticationEntryPoint;
 import com.codewithdean.blog.blogapp.security.JwtAuthenticationFilter;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -18,13 +19,19 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
 
 @Configuration
 @EnableWebSecurity
 @EnableGlobalMethodSecurity(prePostEnabled = true)
 public class SecurityConfig {
 
+    public static final String[] PUBLIC_URLS = {"/api/v1/auth/**", "/v3/api-docs", "/v2/api-docs",
+            "/swagger-resources/**", "/swagger-ui/**", "/webjars/**"
 
+    };
     private final CustomUserDetailService customUserDetailService;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
@@ -42,7 +49,7 @@ public class SecurityConfig {
         http
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("api/v1/auth/**").permitAll()
+                        .requestMatchers(PUBLIC_URLS).permitAll()
                         .requestMatchers(HttpMethod.GET).permitAll()
                         .anyRequest().authenticated()
                 )
@@ -66,5 +73,30 @@ public class SecurityConfig {
     @Autowired
     public void configure(AuthenticationManagerBuilder auth) throws Exception {
         auth.userDetailsService(customUserDetailService).passwordEncoder(passwordEncoder());
+    }
+    @Bean
+    public FilterRegistrationBean coresFilter(){
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+
+        CorsConfiguration corsConfiguration = new CorsConfiguration();
+        corsConfiguration.setAllowCredentials(true);
+        corsConfiguration.addAllowedOriginPattern("*");
+        corsConfiguration.addAllowedHeader("Authorization");
+        corsConfiguration.addAllowedHeader("Content-Type");
+        corsConfiguration.addAllowedHeader("Accept");
+        corsConfiguration.addAllowedMethod("POST");
+        corsConfiguration.addAllowedMethod("GET");
+        corsConfiguration.addAllowedMethod("DELETE");
+        corsConfiguration.addAllowedMethod("PUT");
+        corsConfiguration.addAllowedMethod("OPTIONS");
+        corsConfiguration.setMaxAge(3600L);
+
+        source.registerCorsConfiguration("/**", corsConfiguration);
+
+        FilterRegistrationBean bean = new FilterRegistrationBean(new CorsFilter(source));
+
+        bean.setOrder(-110);
+
+        return bean;
     }
 }

--- a/src/main/java/com/codewithdean/blog/blogapp/config/SecurityConfig.java
+++ b/src/main/java/com/codewithdean/blog/blogapp/config/SecurityConfig.java
@@ -70,6 +70,7 @@ public class SecurityConfig {
         return configuration.getAuthenticationManager();
     }
 
+
     @Autowired
     public void configure(AuthenticationManagerBuilder auth) throws Exception {
         auth.userDetailsService(customUserDetailService).passwordEncoder(passwordEncoder());

--- a/src/main/java/com/codewithdean/blog/blogapp/controllers/AuthController.java
+++ b/src/main/java/com/codewithdean/blog/blogapp/controllers/AuthController.java
@@ -16,10 +16,7 @@ import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.awt.*;
 

--- a/src/main/java/com/codewithdean/blog/blogapp/enities/User.java
+++ b/src/main/java/com/codewithdean/blog/blogapp/enities/User.java
@@ -23,6 +23,7 @@ public class User implements UserDetails {
 
     @Column(name="user_name",  nullable = false, length = 100)
     private String name;
+    @Column(unique=true)
     private String email;
     private String password;
     private String about;


### PR DESCRIPTION
What It Does
CORS Configuration:

UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
This creates a source object that will hold the CORS configuration.

CorsConfiguration corsConfiguration = new CorsConfiguration();
This initializes a CORS configuration object where you define what cross-origin requests are allowed.

corsConfiguration.setAllowCredentials(true);
This allows cookies and other credentials to be included in cross-origin requests.

corsConfiguration.addAllowedOriginPattern("*");
This allows any origin to make cross-origin requests to your application. (Note: Using * is not allowed when allowCredentials is true. This setup might cause issues depending on your Spring version.)

corsConfiguration.addAllowedHeader(...)
These lines specify which headers are allowed in the requests. You’ve allowed Authorization, Content-Type, and Accept.

corsConfiguration.addAllowedMethod(...)
These lines specify which HTTP methods are allowed: POST, GET, DELETE, PUT, and OPTIONS.

corsConfiguration.setMaxAge(3600L);
This sets the maximum time in seconds (3600 seconds = 1 hour) for how long the results of a preflight request can be cached by the browser.

Register CORS Configuration:

source.registerCorsConfiguration("/**", corsConfiguration);
This applies the CORS configuration to all paths (/**).
Filter Registration:

FilterRegistrationBean bean = new FilterRegistrationBean(new CorsFilter(source));
This creates a FilterRegistrationBean that registers a CorsFilter with the previously defined CORS configuration.

bean.setOrder(-110);
This sets the order of the filter in the filter chain. Filters with lower order values have higher precedence.

Return FilterRegistrationBean:

return bean;
This returns the configured FilterRegistrationBean so that it gets applied by the Spring context.
Summary
This code sets up a CORS filter in a Spring Boot application that allows cross-origin requests from any origin (though this may not work if credentials are included), specifies which headers and methods are permitted, and configures caching for preflight requests. It registers this filter in the filter chain with a specific order to ensure it’s applied correctly.